### PR TITLE
Fix Cloudflare API deployment error

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -53,4 +53,4 @@ preview_bucket_name = "hashbin-backups-dev"
 # Durable Objects migrations
 [[migrations]]
 tag = "v1"
-new_classes = ["ContentMetadata", "UserProfile", "PaymentRecord", "ContestRecord", "MessageThread"]
+new_sqlite_classes = ["ContentMetadata", "UserProfile", "PaymentRecord", "ContestRecord", "MessageThread"]


### PR DESCRIPTION
Cloudflare free plan now requires SQLite-backed Durable Objects. Changed migration from new_classes to new_sqlite_classes to resolve deployment error code 10097.