### PR TITLE
Improve R2 bucket creation error handling in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,20 @@ jobs:
 
       - name: Create R2 buckets (development)
         run: |
-          npx wrangler r2 bucket create hashbin-content-dev || echo "Bucket already exists"
-          npx wrangler r2 bucket create hashbin-backups-dev || echo "Bucket already exists"
+          create_bucket() {
+            local bucket_name=$1
+            echo "Creating bucket '$bucket_name'..."
+            output=$(npx wrangler r2 bucket create "$bucket_name" 2>&1) && return 0
+            if echo "$output" | grep -q "\[code: 10004\]"; then
+              echo "Bucket '$bucket_name' already exists (this is OK)"
+              return 0
+            fi
+            echo "ERROR creating bucket '$bucket_name':"
+            echo "$output"
+            return 1
+          }
+          create_bucket hashbin-content-dev
+          create_bucket hashbin-backups-dev
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -151,8 +163,20 @@ jobs:
 
       - name: Create R2 buckets (production)
         run: |
-          npx wrangler r2 bucket create hashbin-content-prod || echo "Bucket already exists"
-          npx wrangler r2 bucket create hashbin-backups-prod || echo "Bucket already exists"
+          create_bucket() {
+            local bucket_name=$1
+            echo "Creating bucket '$bucket_name'..."
+            output=$(npx wrangler r2 bucket create "$bucket_name" 2>&1) && return 0
+            if echo "$output" | grep -q "\[code: 10004\]"; then
+              echo "Bucket '$bucket_name' already exists (this is OK)"
+              return 0
+            fi
+            echo "ERROR creating bucket '$bucket_name':"
+            echo "$output"
+            return 1
+          }
+          create_bucket hashbin-content-prod
+          create_bucket hashbin-backups-prod
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Only ignore "bucket already exists" error (code 10004). Fail the workflow on any other R2 bucket creation error to make problems easier to find.