### PR TITLE
Configure Clerk authentication keys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,17 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Configure Clerk secrets (development)
+        if: ${{ secrets.CLERK_SECRET_KEY != '' && secrets.CLERK_PUBLISHABLE_KEY != '' }}
+        run: |
+          echo "Configuring Clerk secrets for development..."
+          echo "${{ secrets.CLERK_SECRET_KEY }}" | npx wrangler secret put CLERK_SECRET_KEY --env development
+          echo "${{ secrets.CLERK_PUBLISHABLE_KEY }}" | npx wrangler secret put CLERK_PUBLISHABLE_KEY --env development
+          echo "✅ Clerk secrets configured"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Wait for deployment propagation
         run: sleep 10
 
@@ -183,6 +194,17 @@ jobs:
 
       - name: Deploy to Cloudflare Workers (production)
         run: npx wrangler deploy --env production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Configure Clerk secrets (production)
+        if: ${{ secrets.CLERK_SECRET_KEY != '' && secrets.CLERK_PUBLISHABLE_KEY != '' }}
+        run: |
+          echo "Configuring Clerk secrets for production..."
+          echo "${{ secrets.CLERK_SECRET_KEY }}" | npx wrangler secret put CLERK_SECRET_KEY --env production
+          echo "${{ secrets.CLERK_PUBLISHABLE_KEY }}" | npx wrangler secret put CLERK_PUBLISHABLE_KEY --env production
+          echo "✅ Clerk secrets configured"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
GitHub Actions secrets are separate from Cloudflare Worker secrets. The CLERK_SECRET_KEY and CLERK_PUBLISHABLE_KEY were defined in GitHub but never pushed to Cloudflare using 'wrangler secret put'.

This adds steps to both development and production deployments to configure Clerk secrets after the worker is deployed.