### PR TITLE
Add /api/config endpoint to serve Clerk publishable key to frontend

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -12,10 +12,7 @@
   <link rel="stylesheet" href="/css/components.css">
   <link rel="stylesheet" href="/css/auth.css">
   
-  <!-- Clerk Publishable Key (injected at build time) -->
-  <script>
-    window.CLERK_PUBLISHABLE_KEY = 'YOUR_CLERK_PUBLISHABLE_KEY'; // TODO: Replace with actual key
-  </script>
+  <!-- Clerk configuration is loaded from /api/config -->
 </head>
 <body>
   <!-- Navigation Header -->

--- a/frontend/deposit.html
+++ b/frontend/deposit.html
@@ -12,10 +12,7 @@
   <link rel="stylesheet" href="/css/components.css">
   <link rel="stylesheet" href="/css/auth.css">
   
-  <!-- Clerk Publishable Key (injected at build time) -->
-  <script>
-    window.CLERK_PUBLISHABLE_KEY = 'YOUR_CLERK_PUBLISHABLE_KEY'; // TODO: Replace with actual key
-  </script>
+  <!-- Clerk configuration is loaded from /api/config -->
 </head>
 <body>
   <!-- Navigation Header -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,10 +12,7 @@
   <link rel="stylesheet" href="/css/components.css">
   <link rel="stylesheet" href="/css/auth.css">
   
-  <!-- Clerk Publishable Key (injected at build time) -->
-  <script>
-    window.CLERK_PUBLISHABLE_KEY = 'YOUR_CLERK_PUBLISHABLE_KEY'; // TODO: Replace with actual key
-  </script>
+  <!-- Clerk configuration is loaded from /api/config -->
 </head>
 <body>
   <!-- Navigation Header -->

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -15,11 +15,25 @@ const authStateListeners = new Set();
  */
 export async function initializeClerk() {
   try {
-    // Get Clerk publishable key from window (injected at build time)
-    const publishableKey = window.CLERK_PUBLISHABLE_KEY;
-    
+    // Get Clerk publishable key from API config endpoint
+    let publishableKey = null;
+    try {
+      const configResponse = await fetch('/api/config');
+      if (configResponse.ok) {
+        const config = await configResponse.json();
+        publishableKey = config.clerkPublishableKey;
+      }
+    } catch (configError) {
+      console.warn('Failed to fetch config from API:', configError);
+    }
+
+    // Fallback to window variable if API fails
     if (!publishableKey) {
-      console.error('Clerk publishable key not found');
+      publishableKey = window.CLERK_PUBLISHABLE_KEY;
+    }
+
+    if (!publishableKey || publishableKey === 'YOUR_CLERK_PUBLISHABLE_KEY') {
+      console.error('Clerk publishable key not configured');
       return false;
     }
 

--- a/frontend/retrieve.html
+++ b/frontend/retrieve.html
@@ -12,10 +12,7 @@
   <link rel="stylesheet" href="/css/components.css">
   <link rel="stylesheet" href="/css/auth.css">
   
-  <!-- Clerk Publishable Key (injected at build time) -->
-  <script>
-    window.CLERK_PUBLISHABLE_KEY = 'YOUR_CLERK_PUBLISHABLE_KEY'; // TODO: Replace with actual key
-  </script>
+  <!-- Clerk configuration is loaded from /api/config -->
 </head>
 <body>
   <!-- Navigation Header -->

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -12,10 +12,7 @@
   <link rel="stylesheet" href="/css/components.css">
   <link rel="stylesheet" href="/css/auth.css">
   
-  <!-- Clerk Publishable Key (injected at build time) -->
-  <script>
-    window.CLERK_PUBLISHABLE_KEY = 'YOUR_CLERK_PUBLISHABLE_KEY'; // TODO: Replace with actual key
-  </script>
+  <!-- Clerk configuration is loaded from /api/config -->
 </head>
 <body>
   <!-- Navigation Header -->

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,11 @@ function handleApiRoutes(url, request, env) {
     return handleHealth(env);
   }
 
+  // Public config endpoint (serves non-secret configuration to frontend)
+  if (url.pathname === '/api/config' && request.method === 'GET') {
+    return handleConfig(env);
+  }
+
   // Authentication API routes
   if (url.pathname === '/api/auth/callback' && request.method === 'POST') {
     return handleAuthCallback(request, env);
@@ -237,6 +242,24 @@ function handleRoot(env) {
     headers: {
       'content-type': 'application/json',
       'access-control-allow-origin': '*'
+    }
+  });
+}
+
+/**
+ * Public configuration endpoint
+ * Returns non-secret configuration needed by the frontend
+ */
+function handleConfig(env) {
+  const config = {
+    clerkPublishableKey: env.CLERK_PUBLISHABLE_KEY || null
+  };
+
+  return new Response(JSON.stringify(config), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=300' // Cache for 5 minutes
     }
   });
 }


### PR DESCRIPTION
The frontend JavaScript needs the Clerk publishable key to initialize, but it was hardcoded as a placeholder in HTML files. The backend secrets (set via wrangler secret put) aren't exposed to the frontend.

Changes:
- Add /api/config endpoint that returns clerkPublishableKey from env
- Update auth.js to fetch config from API instead of window variable
- Remove hardcoded placeholder from all HTML files

The publishable key is meant to be public (unlike the secret key), so exposing it via API is the intended pattern.