### PR TITLE
Fix Clerk v5 initialization and smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -186,7 +186,7 @@ jobs:
             exit 1
           fi
 
-          if ! echo "$RESPONSE" | grep -q "HashBin.org API"; then
+          if ! echo "$RESPONSE" | grep -q "HashBin"; then
             echo "::error::Root endpoint missing expected content"
             exit 1
           fi

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -42,11 +42,9 @@ export async function initializeClerk() {
       await loadClerkScript();
     }
 
-    // Initialize Clerk
-    clerkInstance = window.Clerk;
-    await clerkInstance.load({
-      publishableKey: publishableKey
-    });
+    // Initialize Clerk v5 - Clerk is a constructor, not an instance
+    clerkInstance = new window.Clerk(publishableKey);
+    await clerkInstance.load();
 
     // Set up auth state listener
     clerkInstance.addListener((session) => {


### PR DESCRIPTION
1. Clerk v5 API change: window.Clerk is a constructor, not an instance.
   Changed from: window.Clerk.load({publishableKey})
   Changed to: new window.Clerk(publishableKey).load()

2. Smoke test: Root endpoint now serves HTML frontend, not API response. Updated check from "HashBin.org API" to "HashBin" to match HTML content.