### PR TITLE
Harden deploy verification against caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,12 +79,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Deploy to Cloudflare Workers
-        run: npx wrangler deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
       - name: Verify required secrets
         run: |
           echo "Verifying required secrets are configured..."
@@ -193,6 +187,18 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: List configured secrets (diagnostic)
+        run: npx wrangler secret list
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy to Cloudflare Workers
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Wait for deployment propagation
         run: sleep 10
 
@@ -201,12 +207,16 @@ jobs:
           GIT_SHA=$(git rev-parse HEAD)
           echo "Expected git SHA: $GIT_SHA"
           echo "Testing custom domain hashbin.org..."
-          RESPONSE=$(curl -s -w "\n%{http_code}" https://hashbin.org/health)
+          CACHE_BUSTER=$(date +%s)
+          RESPONSE_HEADERS=$(mktemp)
+          RESPONSE=$(curl -s -D "$RESPONSE_HEADERS" -H "Cache-Control: no-cache" -H "Pragma: no-cache" -w "\n%{http_code}" "https://hashbin.org/health?ts=${CACHE_BUSTER}")
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY=$(echo "$RESPONSE" | head -n-1)
 
           echo "HTTP Status Code: $HTTP_CODE"
           echo "Response Body: $BODY"
+          echo "Response Headers:"
+          cat "$RESPONSE_HEADERS"
 
           if [ "$HTTP_CODE" != "200" ]; then
             echo "❌ Health endpoint returned HTTP $HTTP_CODE (expected 200)"
@@ -233,23 +243,49 @@ jobs:
             echo "⚠️  Environment field shows unexpected value (non-critical)"
           fi
 
+          if ! grep -qi "^x-git-sha: $GIT_SHA" "$RESPONSE_HEADERS"; then
+            echo "❌ Missing or mismatched x-git-sha header"
+            exit 1
+          fi
+
+          if ! grep -qi "^x-git-sha-present: true" "$RESPONSE_HEADERS"; then
+            echo "⚠️  x-git-sha-present header is not true"
+          fi
+
           echo "✅ Custom domain verified"
 
       - name: Verify git SHA in HTML files
         run: |
           GIT_SHA=$(git rev-parse HEAD)
           echo "Verifying git SHA in HTML files..."
-          
-          # Test the index page
-          HTML_RESPONSE=$(curl -s https://hashbin.org/)
-          
-          if echo "$HTML_RESPONSE" | grep -q "<!-- git-sha: $GIT_SHA -->"; then
-            echo "✅ Git SHA found in HTML: $GIT_SHA"
-          else
-            echo "❌ Git SHA not found in HTML files"
-            echo "Expected: <!-- git-sha: $GIT_SHA -->"
-            exit 1
-          fi
+          CACHE_BUSTER=$(date +%s)
+
+          PAGES=(
+            "/"
+            "/upload.html"
+            "/dashboard.html"
+            "/api-keys.html"
+            "/info.html"
+          )
+
+          for PAGE in "${PAGES[@]}"; do
+            echo "Checking $PAGE..."
+            RESPONSE_HEADERS=$(mktemp)
+            HTML_RESPONSE=$(curl -s -D "$RESPONSE_HEADERS" -H "Cache-Control: no-cache" -H "Pragma: no-cache" "https://hashbin.org${PAGE}?ts=${CACHE_BUSTER}")
+
+            if echo "$HTML_RESPONSE" | grep -q "<!-- git-sha: $GIT_SHA -->"; then
+              echo "✅ Git SHA found in HTML: $GIT_SHA ($PAGE)"
+            else
+              echo "❌ Git SHA not found in HTML for $PAGE"
+              echo "Expected: <!-- git-sha: $GIT_SHA -->"
+              exit 1
+            fi
+
+            if ! grep -qi "^x-git-sha: $GIT_SHA" "$RESPONSE_HEADERS"; then
+              echo "❌ Missing or mismatched x-git-sha header for $PAGE"
+              exit 1
+            fi
+          done
 
       - name: Verify deployment - Workers.dev URL
         continue-on-error: true

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ import { applyRateLimit, authenticate } from './auth/middleware.js';
 const VALID_ENVIRONMENTS = ['development', 'production'];
 const VALID_LOG_LEVELS = ['debug', 'info', 'warn', 'error'];
 const HEALTH_CHECK_ID = 'health-check';
+const GIT_SHA_PLACEHOLDER = 'unknown';
 
 // Static paths that should not be matched as CIDs
 // These paths are served by the ASSETS binding (frontend files)
@@ -127,7 +128,7 @@ export default {
           const detailRequest = new Request(new URL('/dashboard/uploads/detail.html', url), request);
           const detailAsset = await env.ASSETS.fetch(detailRequest);
           if (detailAsset.status !== 404) {
-            return detailAsset;
+            return withGitShaComment(detailAsset, env);
           }
         }
         
@@ -136,7 +137,7 @@ export default {
         
         // If asset found, return it
         if (asset.status !== 404) {
-          return asset;
+          return withGitShaComment(asset, env);
         }
         
         // If requesting a path without extension, try index.html
@@ -144,7 +145,7 @@ export default {
           const indexRequest = new Request(new URL('/index.html', url), request);
           const indexAsset = await env.ASSETS.fetch(indexRequest);
           if (indexAsset.status !== 404) {
-            return indexAsset;
+            return withGitShaComment(indexAsset, env);
           }
         }
       } catch (error) {
@@ -309,6 +310,45 @@ function handleApiRoutes(url, request, env) {
   return new Response('Not Found', { status: 404 });
 }
 
+function injectGitShaIntoHtml(html, gitSha) {
+  const comment = `<!-- git-sha: ${gitSha} -->`;
+  const commentRegex = /<!--\s*git-sha:[^>]*-->/i;
+
+  if (commentRegex.test(html)) {
+    return html.replace(commentRegex, comment);
+  }
+
+  const doctypeMatch = html.match(/<!doctype[^>]*>/i);
+  if (doctypeMatch) {
+    return html.replace(doctypeMatch[0], `${doctypeMatch[0]}\n${comment}`);
+  }
+
+  return `${comment}\n${html}`;
+}
+
+async function withGitShaComment(response, env) {
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('text/html')) {
+    return response;
+  }
+
+  const gitSha = env.GIT_SHA || GIT_SHA_PLACEHOLDER;
+  const html = await response.text();
+  const updatedHtml = injectGitShaIntoHtml(html, gitSha);
+  const headers = new Headers(response.headers);
+  headers.delete('content-length');
+  headers.set('cache-control', 'no-store, max-age=0, must-revalidate');
+  headers.set('pragma', 'no-cache');
+  headers.set('x-git-sha', gitSha);
+  headers.set('x-git-sha-present', String(Boolean(env.GIT_SHA)));
+
+  return new Response(updatedHtml, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
 /**
  * Root endpoint - Basic info
  */
@@ -376,11 +416,16 @@ async function handleHealth(env) {
     overallStatus = 'degraded';
   }
 
+  if (!env.GIT_SHA) {
+    console.warn('Health check: GIT_SHA secret is not configured.');
+  }
+
   const health = {
     status: overallStatus,
     timestamp: new Date().toISOString(),
     environment: env.ENVIRONMENT || 'unknown',
-    gitSha: env.GIT_SHA || 'unknown',
+    gitSha: env.GIT_SHA || GIT_SHA_PLACEHOLDER,
+    gitShaPresent: Boolean(env.GIT_SHA),
     checks: checks,
     summary: {
       total: Object.keys(checks).length,
@@ -396,7 +441,11 @@ async function handleHealth(env) {
     status: statusCode,
     headers: {
       'content-type': 'application/json',
-      'access-control-allow-origin': '*'
+      'access-control-allow-origin': '*',
+      'cache-control': 'no-store, max-age=0, must-revalidate',
+      'pragma': 'no-cache',
+      'x-git-sha': env.GIT_SHA || GIT_SHA_PLACEHOLDER,
+      'x-git-sha-present': String(Boolean(env.GIT_SHA))
     }
   });
 }


### PR DESCRIPTION
### Motivation
- Deployment checks were intermittently failing to detect stale/old deployments because Cloudflare edges could serve cached HTML/health responses that lacked the current `GIT_SHA`.
- The goal is to ensure the runtime-exposed git SHA is reliably visible and that CI verification cannot be bypassed by cached responses.

### Description
- Add `GIT_SHA_PLACEHOLDER`, `injectGitShaIntoHtml()` and `withGitShaComment()` to `src/index.js` and wrap asset responses so HTML pages are annotated with `<!-- git-sha: ... -->` and response headers include `x-git-sha` and `x-git-sha-present`.
- Set `cache-control: no-store, max-age=0, must-revalidate` and `pragma: no-cache` for served HTML and the `/health` JSON response to avoid stale edge caching.
- Enhance `/health` to include `gitSha` and `gitShaPresent` fields and to emit `x-git-sha` / `x-git-sha-present` headers for verification.
- Update `.github/workflows/deploy.yml` to perform cache-busted requests, capture and log response headers, assert the `x-git-sha` header for `/health` and multiple HTML pages, add a diagnostic `npx wrangler secret list` step, and move the `wrangler deploy` step after secret configuration.

### Testing
- No automated tests were executed locally; CI is expected to run the repository `test` job and the updated deployment verification steps (health JSON checks, header assertions, and HTML page checks) as part of the workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696bd9c554e0833185cc0d224d4e9938)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced deployment verification with diagnostic steps and improved health checks including cache-busting and response header validation
  * Added Git SHA tracking across HTML assets with per-page verification for better deployment integrity validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->