### PR TITLE
Add fully-local dev mode: local auth, mock payments, and auth-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,30 @@ See [todo/master_plan.md](todo/master_plan.md) for the complete roadmap.
 
 The development server runs at `http://localhost:8787`
 
+### Local-Only Development (No External Services)
+
+Use the fully local mode to run without Clerk or Stripe:
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+2. **Start local mode**
+   ```bash
+   npm run dev:local
+   ```
+
+3. **Sign in locally**
+   - Click **Sign In** in the UI and enter a username, or
+   - Send requests with `Authorization: LocalDev <user_id>`.
+
+For full details, see [docs/local-development.md](docs/local-development.md).
+
 ### Available Scripts
 
 - `npm run dev` - Start local development server
+- `npm run dev:local` - Start local development with local auth/payments
 - `npm run deploy` - Deploy to production
 - `npm run verify` - Verify production deployment
 - `npm test` - Run test suite

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,63 @@
+# Local Development (Fully Offline)
+
+This guide describes how to run HashBin.org entirely locally without external services (Clerk, Stripe, or Cloudflare production infrastructure).
+
+## Prerequisites
+
+- Node.js 20+
+- npm
+
+## Quick Start
+
+```bash
+npm install
+npm run dev:local
+```
+
+The app runs at `http://localhost:8787`.
+
+## Local Authentication
+
+Local mode replaces Clerk with a lightweight username prompt:
+
+- Click **Sign In** in the UI and enter a username.
+- API calls can use the header:
+
+```
+Authorization: LocalDev <user_id>
+```
+
+User IDs are free-form strings (up to 256 characters).
+New local users start with a $10.00 balance for convenience.
+
+## Local Payments
+
+Stripe is disabled in local mode. Use the dev deposit endpoint instead:
+
+```bash
+curl -X POST http://localhost:8787/api/balance/dev-deposit \
+  -H "Authorization: LocalDev demo_user" \
+  -H "Content-Type: application/json" \
+  --data '{"amount_cents": 1000}'
+```
+
+This credits the local balance immediately and records a transaction in history.
+
+## Helpful Endpoints
+
+- `GET /health` — confirms the server is running and shows `environment: "local"`
+- `GET /api/config` — returns `isLocalMode: true` and `authMode: "local"`
+
+## Debugging Tips
+
+- Wrangler local state is stored in `.wrangler/state`.
+- Use `npm run dev` to compare behavior against production-like mode.
+- If UI auth doesn’t appear, refresh and ensure `/api/config` is reachable.
+
+## Local Test Script
+
+Run a basic local check (server must already be running):
+
+```bash
+scripts/test-local-mode.sh
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,6 +7,7 @@ This directory contains the frontend web interface for HashBin.org.
 The frontend is built using vanilla HTML, CSS, and JavaScript (ES6+ modules) with no build step required. It integrates with:
 
 - **Clerk JavaScript SDK** for OAuth authentication (Google, Apple, Microsoft, GitHub)
+- **Local auth module** for offline/local development
 - **HashBin.org API** (Cloudflare Workers backend) for balance, content operations, and user management
 
 ## Structure
@@ -25,7 +26,9 @@ frontend/
 │   └── auth.css           # Authentication UI components
 └── js/
     ├── app.js             # Main application entry point
+    ├── auth-loader.js     # Auth mode switcher (Clerk vs local)
     ├── auth.js            # Clerk SDK integration
+    ├── local-auth.js      # Local auth implementation
     ├── auth-gate.js       # Protected page middleware
     └── utils.js           # Utility functions
 ```
@@ -34,15 +37,8 @@ frontend/
 
 ### Clerk Publishable Key
 
-The Clerk publishable key must be configured in each HTML file. Replace the placeholder:
-
-```javascript
-window.CLERK_PUBLISHABLE_KEY = 'YOUR_CLERK_PUBLISHABLE_KEY';
-```
-
-With your actual Clerk publishable key:
-- Development: `pk_test_...`
-- Production: `pk_live_...`
+The backend supplies the Clerk publishable key via `/api/config` when running in non-local mode.
+Set `CLERK_PUBLISHABLE_KEY` in your Worker environment (Wrangler or secrets) to enable Clerk.
 
 ### Backend API
 
@@ -125,7 +121,7 @@ const formatted = formatBalance(data.balance_cents);
 To check current auth state:
 
 ```javascript
-import { getAuthState } from './js/auth.js';
+import { getAuthState } from './js/auth-loader.js';
 
 const authState = await getAuthState();
 if (authState.authenticated) {

--- a/frontend/api-keys-detail.html
+++ b/frontend/api-keys-detail.html
@@ -466,7 +466,6 @@
       getKeyPrefix,
       copyToClipboard
     } from './js/api-keys.js';
-    import { getSessionToken } from './js/auth.js';
     
     // Protect this page - require authentication
     await requireAuth();

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -4,13 +4,13 @@
  */
 
 import { 
-  initializeClerk, 
+  initializeAuth, 
   getAuthState, 
   signIn, 
   signOut, 
   onAuthStateChange,
   getProviderIcon
-} from './auth.js';
+} from './auth-loader.js';
 
 import { 
   authenticatedFetch, 
@@ -34,15 +34,15 @@ async function init() {
   console.log('Initializing HashBin.org application...');
   
   // Initialize Clerk
-  const clerkInitialized = await initializeClerk();
+  const authInitialized = await initializeAuth();
   
-  if (!clerkInitialized) {
+  if (!authInitialized) {
     showAuthError('Authentication service unavailable');
     return;
   }
 
   // Set up auth state listener
-  onAuthStateChange(handleAuthChange);
+  await onAuthStateChange(handleAuthChange);
 
   // Update UI with initial auth state
   await updateAuthUI();
@@ -73,7 +73,8 @@ async function updateAuthUI() {
 
   // Update UI based on auth state
   if (authState.authenticated) {
-    authSection.innerHTML = createAuthenticatedHTML(authState.user);
+    const providerIcon = await getProviderIcon(authState.user.provider);
+    authSection.innerHTML = createAuthenticatedHTML(authState.user, providerIcon);
     setupAuthenticatedHandlers();
     // Fetch and display balance
     await updateBalance();
@@ -119,8 +120,7 @@ function createUnauthenticatedHTML() {
 /**
  * Create HTML for authenticated state
  */
-function createAuthenticatedHTML(user) {
-  const providerIcon = getProviderIcon(user.provider);
+function createAuthenticatedHTML(user, providerIcon) {
   // Only render provider icon if we have a non-empty src
   const providerIconHTML = providerIcon
     ? `<img class="provider-icon" src="${providerIcon}" alt="${user.provider || ''}" title="Signed in with ${user.provider}">` 

--- a/frontend/js/auth-gate.js
+++ b/frontend/js/auth-gate.js
@@ -4,7 +4,7 @@
  * Redirects unauthenticated users to the landing page
  */
 
-import { getAuthState } from './auth.js';
+import { getAuthState, initializeAuth } from './auth-loader.js';
 import { redirectWithReturn, getReturnUrl } from './utils.js';
 
 /**
@@ -23,8 +23,8 @@ export async function requireAuth(options = {}) {
     showAuthGateLoading();
   }
 
-  // Wait a bit for Clerk to initialize
-  await waitForClerkInit();
+  // Initialize auth module (Clerk or local)
+  await initializeAuth();
 
   // Check auth state
   const authState = await getAuthState();
@@ -41,46 +41,6 @@ export async function requireAuth(options = {}) {
   }
 
   return true;
-}
-
-/**
- * Wait for Clerk to initialize
- * @param {number} maxWait Maximum wait time in ms
- * @returns {Promise<void>}
- */
-async function waitForClerkInit(maxWait = 5000) {
-  const startTime = Date.now();
-  
-  // First, wait for window.Clerk to exist
-  while (!window.Clerk && (Date.now() - startTime) < maxWait) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-  
-  // If Clerk doesn't exist after waiting, return
-  if (!window.Clerk) {
-    return;
-  }
-  
-  // Now wait for Clerk to be fully loaded
-  // Poll the loaded property instead of relying on Promise.race
-  let loadInitiated = false;
-  while ((!window.Clerk.loaded) && (Date.now() - startTime) < maxWait) {
-    try {
-      // Trigger load once if not already loading/loaded
-      if (!loadInitiated && window.Clerk.load && typeof window.Clerk.load === 'function') {
-        loadInitiated = true;
-        // Note: We don't await here because we're polling the loaded property
-        window.Clerk.load().catch(err => {
-          console.warn('Clerk load error:', err);
-        });
-      }
-      // Wait a bit before checking again
-      await new Promise(resolve => setTimeout(resolve, 100));
-    } catch (error) {
-      console.warn('Error checking Clerk loaded state:', error);
-      break;
-    }
-  }
 }
 
 /**

--- a/frontend/js/auth-loader.js
+++ b/frontend/js/auth-loader.js
@@ -1,0 +1,71 @@
+/**
+ * Auth Module Loader
+ * Chooses Clerk or local auth based on /api/config.
+ */
+
+let authModulePromise = null;
+
+async function loadAuthModule() {
+  if (!authModulePromise) {
+    authModulePromise = (async () => {
+      let authMode = 'clerk';
+      try {
+        const response = await fetch('/api/config');
+        if (response.ok) {
+          const config = await response.json();
+          authMode = config.authMode || (config.isLocalMode ? 'local' : 'clerk');
+        }
+      } catch (error) {
+        console.warn('Failed to detect auth mode, defaulting to Clerk.', error);
+      }
+
+      if (authMode === 'local') {
+        return import('./local-auth.js');
+      }
+
+      return import('./auth.js');
+    })();
+  }
+
+  return authModulePromise;
+}
+
+export async function initializeAuth() {
+  const module = await loadAuthModule();
+  return module.initializeAuth ? module.initializeAuth() : true;
+}
+
+export async function getAuthState() {
+  const module = await loadAuthModule();
+  return module.getAuthState();
+}
+
+export async function signIn() {
+  const module = await loadAuthModule();
+  return module.signIn();
+}
+
+export async function signOut() {
+  const module = await loadAuthModule();
+  return module.signOut();
+}
+
+export async function getSessionToken() {
+  const module = await loadAuthModule();
+  return module.getSessionToken();
+}
+
+export async function getAuthHeaders() {
+  const module = await loadAuthModule();
+  return module.getAuthHeaders();
+}
+
+export async function onAuthStateChange(callback) {
+  const module = await loadAuthModule();
+  return module.onAuthStateChange(callback);
+}
+
+export async function getProviderIcon(provider) {
+  const module = await loadAuthModule();
+  return module.getProviderIcon(provider);
+}

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -13,7 +13,7 @@ const authStateListeners = new Set();
  * Initialize Clerk SDK
  * @returns {Promise<boolean>} True if initialization succeeded
  */
-export async function initializeClerk() {
+export async function initializeAuth() {
   try {
     // Get Clerk publishable key from API config endpoint
     let publishableKey = null;
@@ -61,6 +61,9 @@ export async function initializeClerk() {
     return false;
   }
 }
+
+// Legacy alias for compatibility
+export const initializeClerk = initializeAuth;
 
 /**
  * Load Clerk script from CDN
@@ -205,6 +208,21 @@ export async function getSessionToken() {
     console.error('Failed to get session token:', error);
     return null;
   }
+}
+
+/**
+ * Get authentication headers for API requests
+ * @returns {Promise<Object|null>} Headers object or null if unauthenticated
+ */
+export async function getAuthHeaders() {
+  const token = await getSessionToken();
+  if (!token) {
+    return null;
+  }
+
+  return {
+    Authorization: `Bearer ${token}`
+  };
 }
 
 /**

--- a/frontend/js/deposit.js
+++ b/frontend/js/deposit.js
@@ -3,10 +3,11 @@
  * Handles deposit form, fee calculation, and Stripe checkout
  */
 
-import { authenticatedFetch, formatBalance, showToast, handleApiError } from './utils.js';
+import { authenticatedFetch, showToast, handleApiError } from './utils.js';
 
 // Constants
 const MINIMUM_DEPOSIT_DOLLARS = 1.00;
+const LOCAL_MINIMUM_DEPOSIT_DOLLARS = 0.01;
 const STRIPE_FEE_PERCENTAGE = 0.029;
 const STRIPE_FEE_FIXED_CENTS = 30;
 
@@ -21,11 +22,12 @@ let depositForm;
 let successMessage;
 let cancelMessage;
 let errorMessage;
+let isLocalMode = false;
 
 /**
  * Initialize deposit page
  */
-function init() {
+async function init() {
   // Get DOM elements
   amountInput = document.getElementById('amount');
   submitBtn = document.getElementById('submit-btn');
@@ -43,6 +45,9 @@ function init() {
     return;
   }
 
+  await detectLocalMode();
+  updateModeUI();
+
   // Check for status in URL (success/cancel redirects)
   handleUrlStatus();
 
@@ -51,6 +56,49 @@ function init() {
   depositForm.addEventListener('submit', handleFormSubmit);
 
   console.log('Deposit page initialized');
+}
+
+async function detectLocalMode() {
+  try {
+    const response = await fetch('/api/config');
+    if (!response.ok) {
+      return;
+    }
+    const config = await response.json();
+    isLocalMode = Boolean(config.isLocalMode || config.authMode === 'local');
+  } catch (error) {
+    console.warn('Unable to detect local mode:', error);
+  }
+}
+
+function updateModeUI() {
+  if (!isLocalMode) {
+    return;
+  }
+
+  const heading = document.querySelector('.card-title');
+  const description = document.querySelector('.card p');
+
+  if (heading) {
+    heading.textContent = 'Add Funds (Local Mode)';
+  }
+
+  if (description) {
+    description.textContent = 'Add test funds directly to your local account balance.';
+  }
+
+  const successParagraph = successMessage?.querySelector('p');
+  if (successParagraph) {
+    successParagraph.textContent = 'Your balance has been updated.';
+  }
+
+  const helperText = document.querySelector('.form-text');
+  if (helperText) {
+    helperText.textContent = `Minimum: $${LOCAL_MINIMUM_DEPOSIT_DOLLARS.toFixed(2)}`;
+  }
+
+  submitBtn.textContent = 'Add Funds';
+  feeBreakdown.classList.add('hidden');
 }
 
 /**
@@ -95,29 +143,32 @@ function handleAmountChange() {
   }
 
   const amountDollars = parseFloat(value);
+  const minimumDeposit = isLocalMode ? LOCAL_MINIMUM_DEPOSIT_DOLLARS : MINIMUM_DEPOSIT_DOLLARS;
   
   // Validate amount
-  if (isNaN(amountDollars) || amountDollars < MINIMUM_DEPOSIT_DOLLARS) {
+  if (isNaN(amountDollars) || amountDollars < minimumDeposit) {
     feeBreakdown.classList.add('hidden');
     submitBtn.disabled = true;
     
     if (amountDollars > 0) {
-      showError(`Minimum deposit is $${MINIMUM_DEPOSIT_DOLLARS.toFixed(2)}`);
+      showError(`Minimum deposit is $${minimumDeposit.toFixed(2)}`);
     }
     return;
   }
 
-  // Calculate fees
-  const amountCents = Math.round(amountDollars * 100);
-  const fees = calculateFees(amountCents);
-  
-  // Update breakdown display
-  creditAmountSpan.textContent = formatDollars(fees.creditCents);
-  feeAmountSpan.textContent = formatDollars(fees.feeCents);
-  totalAmountSpan.textContent = formatDollars(fees.totalChargeCents);
-  
-  // Show breakdown
-  feeBreakdown.classList.remove('hidden');
+  if (!isLocalMode) {
+    // Calculate fees
+    const amountCents = Math.round(amountDollars * 100);
+    const fees = calculateFees(amountCents);
+    
+    // Update breakdown display
+    creditAmountSpan.textContent = formatDollars(fees.creditCents);
+    feeAmountSpan.textContent = formatDollars(fees.feeCents);
+    totalAmountSpan.textContent = formatDollars(fees.totalChargeCents);
+    
+    // Show breakdown
+    feeBreakdown.classList.remove('hidden');
+  }
   
   // Enable submit button
   submitBtn.disabled = false;
@@ -162,19 +213,20 @@ async function handleFormSubmit(event) {
   const amountCents = Math.round(amountDollars * 100);
   
   // Validate
-  if (isNaN(amountCents) || amountCents < 100) {
-    showError('Please enter a valid amount (minimum $1.00)');
+  const minimumCents = Math.round((isLocalMode ? LOCAL_MINIMUM_DEPOSIT_DOLLARS : MINIMUM_DEPOSIT_DOLLARS) * 100);
+  if (isNaN(amountCents) || amountCents < minimumCents) {
+    showError(`Please enter a valid amount (minimum $${(minimumCents / 100).toFixed(2)})`);
     return;
   }
 
   // Disable form
   submitBtn.disabled = true;
-  submitBtn.textContent = 'Creating checkout session...';
+  submitBtn.textContent = isLocalMode ? 'Adding funds...' : 'Creating checkout session...';
   submitBtn.classList.add('loading');
 
   try {
-    // Call API to create checkout session
-    const response = await authenticatedFetch('/api/balance/deposit', {
+    const endpoint = isLocalMode ? '/api/balance/dev-deposit' : '/api/balance/deposit';
+    const response = await authenticatedFetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -187,6 +239,15 @@ async function handleFormSubmit(event) {
     await handleApiError(response);
     const data = await response.json();
 
+    if (isLocalMode) {
+      successMessage.classList.remove('hidden');
+      showToast(`Added ${formatDollars(data.amount_cents)} to your balance.`, 'success');
+      submitBtn.textContent = 'Add Funds';
+      submitBtn.disabled = false;
+      submitBtn.classList.remove('loading');
+      return;
+    }
+
     // Redirect to Stripe checkout
     window.location.href = data.checkout_url;
   } catch (error) {
@@ -195,7 +256,7 @@ async function handleFormSubmit(event) {
     
     // Re-enable form
     submitBtn.disabled = false;
-    submitBtn.textContent = 'Add Funds via Stripe';
+    submitBtn.textContent = isLocalMode ? 'Add Funds' : 'Add Funds via Stripe';
     submitBtn.classList.remove('loading');
   }
 }

--- a/frontend/js/local-auth.js
+++ b/frontend/js/local-auth.js
@@ -1,0 +1,137 @@
+/**
+ * Local Authentication Module
+ * Simple username-based auth for local development.
+ */
+
+const STORAGE_KEY = 'hashbin.localAuthUser';
+const authStateListeners = new Set();
+
+function loadStoredUser() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (error) {
+    return null;
+  }
+}
+
+function saveStoredUser(user) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+}
+
+function clearStoredUser() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+function createAvatarDataUrl(initials) {
+  const safeInitials = initials || 'U';
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+      <rect width="64" height="64" rx="32" fill="#3b82f6" />
+      <text x="32" y="38" text-anchor="middle" font-size="24" fill="#ffffff" font-family="Arial, sans-serif">${safeInitials}</text>
+    </svg>
+  `;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+function buildUserProfile(userId) {
+  const displayName = userId;
+  const initials = displayName
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(part => part[0].toUpperCase())
+    .join('');
+
+  return {
+    id: userId,
+    firstName: displayName,
+    lastName: '',
+    fullName: displayName,
+    email: null,
+    imageUrl: createAvatarDataUrl(initials),
+    provider: 'local'
+  };
+}
+
+function notifyAuthStateChange() {
+  authStateListeners.forEach(callback => {
+    try {
+      callback(loadStoredUser());
+    } catch (error) {
+      console.error('Auth state listener error:', error);
+    }
+  });
+}
+
+export async function initializeAuth() {
+  return true;
+}
+
+export async function getAuthState() {
+  const stored = loadStoredUser();
+  if (!stored) {
+    return { authenticated: false };
+  }
+
+  return {
+    authenticated: true,
+    user: buildUserProfile(stored.userId),
+    sessionId: null
+  };
+}
+
+export function signIn() {
+  const input = prompt('Enter a username for local mode');
+  if (input === null) {
+    return;
+  }
+
+  const userId = input.trim();
+  if (!userId) {
+    alert('Username cannot be empty.');
+    return;
+  }
+
+  if (userId.length > 256) {
+    alert('Username must be 256 characters or less.');
+    return;
+  }
+
+  saveStoredUser({ userId });
+  notifyAuthStateChange();
+}
+
+export async function signOut() {
+  clearStoredUser();
+  notifyAuthStateChange();
+  window.location.href = '/';
+}
+
+export async function getSessionToken() {
+  const stored = loadStoredUser();
+  return stored ? stored.userId : null;
+}
+
+export async function getAuthHeaders() {
+  const stored = loadStoredUser();
+  if (!stored) {
+    return null;
+  }
+
+  return {
+    Authorization: `LocalDev ${stored.userId}`
+  };
+}
+
+export function onAuthStateChange(callback) {
+  authStateListeners.add(callback);
+  return () => {
+    authStateListeners.delete(callback);
+  };
+}
+
+export function getProviderIcon() {
+  return '';
+}

--- a/frontend/js/upload.js
+++ b/frontend/js/upload.js
@@ -5,7 +5,7 @@
 
 import { generate256tHash, getContentSize, formatFileSize, isInlineContent } from './hash256t.js';
 import { authenticatedFetch } from './utils.js';
-import { getSessionToken } from './auth.js';
+import { getAuthHeaders } from './auth-loader.js';
 
 // Constants
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
@@ -332,8 +332,8 @@ async function handleUpload(event) {
     uploadAbortController = new AbortController();
     
     // Get auth token
-    const token = await getSessionToken();
-    if (!token) {
+    const authHeaders = await getAuthHeaders();
+    if (!authHeaders) {
       hideUploadProgress();
       showError('Not authenticated. Please sign in again.');
       return;
@@ -343,9 +343,7 @@ async function handleUpload(event) {
     const response = await fetch('/api/content', {
       method: 'POST',
       body: formData,
-      headers: {
-        'Authorization': `Bearer ${token}`
-      },
+      headers: authHeaders,
       signal: uploadAbortController.signal
     });
     

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -22,16 +22,16 @@ export function formatBalance(cents) {
  */
 export async function authenticatedFetch(url, options = {}) {
   // Import dynamically to avoid circular dependency
-  const { getSessionToken } = await import('./auth.js');
-  const token = await getSessionToken();
+  const { getAuthHeaders } = await import('./auth-loader.js');
+  const authHeaders = await getAuthHeaders();
   
-  if (!token) {
+  if (!authHeaders) {
     throw new Error('Not authenticated');
   }
 
   const headers = {
     ...options.headers,
-    'Authorization': `Bearer ${token}`
+    ...authHeaders
   };
 
   return fetch(url, { ...options, headers });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
+    "dev:local": "wrangler dev --config wrangler.local.toml --local",
     "deploy": "wrangler deploy",
     "deploy:dev": "wrangler deploy",
     "deploy:prod": "wrangler deploy",

--- a/scripts/test-local-mode.sh
+++ b/scripts/test-local-mode.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${1:-http://localhost:8787}
+
+function check_endpoint() {
+  local url=$1
+  local label=$2
+
+  echo "Checking ${label}: ${url}"
+  local response
+  response=$(curl -s --fail "$url" || true)
+
+  if [[ -z "$response" ]]; then
+    echo "❌ ${label} failed (no response). Is the local server running?"
+    exit 1
+  fi
+
+  echo "$response" | head -n 5
+}
+
+check_endpoint "${BASE_URL}/health" "health"
+check_endpoint "${BASE_URL}/api/config" "config"
+
+if curl -s --fail -X POST "${BASE_URL}/api/balance/dev-deposit" \
+  -H "Authorization: LocalDev local_test_user" \
+  -H "Content-Type: application/json" \
+  --data '{"amount_cents": 100}' >/dev/null; then
+  echo "✅ Local dev deposit endpoint reachable"
+else
+  echo "⚠️  Local dev deposit endpoint did not respond (auth may be required)"
+fi

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -99,6 +99,7 @@ export async function handleSessionInfo(request, env) {
  */
 export async function handleLogout(request, env) {
   const authResult = await authenticate(request, env);
+  const isLocalMode = env.ENVIRONMENT === 'local';
 
   // Require authentication
   const authError = requireAuth(authResult);
@@ -106,6 +107,19 @@ export async function handleLogout(request, env) {
 
   // Only Clerk sessions can be logged out
   if (authResult.user.authMethod !== 'clerk') {
+    if (isLocalMode && authResult.user.authMethod === 'local') {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: 'Local session cleared'
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        }
+      );
+    }
+
     return new Response(
       JSON.stringify({
         error: 'Invalid authentication method',
@@ -243,16 +257,17 @@ export async function handleLinkProvider(request, env) {
  */
 export async function handleCreateApiKey(request, env) {
   const authResult = await authenticate(request, env);
+  const isLocalMode = env.ENVIRONMENT === 'local';
 
   // Require Clerk session (API keys can't create other API keys)
   const authError = requireAuth(authResult);
   if (authError) return authError;
 
-  if (authResult.user.authMethod !== 'clerk') {
+  if (authResult.user.authMethod !== 'clerk' && !(isLocalMode && authResult.user.authMethod === 'local')) {
     return new Response(
       JSON.stringify({
         error: 'Invalid authentication method',
-        message: 'API keys cannot be used to create new API keys. Use Clerk session.'
+        message: 'API keys cannot be used to create new API keys. Use Clerk session (or local auth in local mode).'
       }),
       {
         status: 403,
@@ -354,19 +369,22 @@ export async function handleCreateApiKey(request, env) {
   const keyId = generateKeyId();
 
   // Encrypt the API key for reveal functionality
-  if (!env.API_KEY_ENCRYPTION_KEY) {
-    return new Response(
-      JSON.stringify({
-        error: 'Encryption key not configured',
-        message: 'API_KEY_ENCRYPTION_KEY secret must be set'
-      }),
-      {
-        status: 500,
-        headers: { 'content-type': 'application/json' }
-      }
-    );
+  let keyEncrypted = apiKey;
+  if (!isLocalMode) {
+    if (!env.API_KEY_ENCRYPTION_KEY) {
+      return new Response(
+        JSON.stringify({
+          error: 'Encryption key not configured',
+          message: 'API_KEY_ENCRYPTION_KEY secret must be set'
+        }),
+        {
+          status: 500,
+          headers: { 'content-type': 'application/json' }
+        }
+      );
+    }
+    keyEncrypted = await encryptApiKey(apiKey, env.API_KEY_ENCRYPTION_KEY);
   }
-  const keyEncrypted = await encryptApiKey(apiKey, env.API_KEY_ENCRYPTION_KEY);
 
   // Store in UserProfile DO
   const response = await userProfileStub.fetch(
@@ -432,16 +450,17 @@ export async function handleCreateApiKey(request, env) {
  */
 export async function handleListApiKeys(request, env) {
   const authResult = await authenticate(request, env);
+  const isLocalMode = env.ENVIRONMENT === 'local';
 
   // Require Clerk session
   const authError = requireAuth(authResult);
   if (authError) return authError;
 
-  if (authResult.user.authMethod !== 'clerk') {
+  if (authResult.user.authMethod !== 'clerk' && !(isLocalMode && authResult.user.authMethod === 'local')) {
     return new Response(
       JSON.stringify({
         error: 'Invalid authentication method',
-        message: 'Use Clerk session to list API keys'
+        message: 'Use Clerk session (or local auth in local mode) to list API keys'
       }),
       {
         status: 403,
@@ -474,16 +493,17 @@ export async function handleListApiKeys(request, env) {
  */
 export async function handleRevokeApiKey(request, env, keyId) {
   const authResult = await authenticate(request, env);
+  const isLocalMode = env.ENVIRONMENT === 'local';
 
   // Require Clerk session
   const authError = requireAuth(authResult);
   if (authError) return authError;
 
-  if (authResult.user.authMethod !== 'clerk') {
+  if (authResult.user.authMethod !== 'clerk' && !(isLocalMode && authResult.user.authMethod === 'local')) {
     return new Response(
       JSON.stringify({
         error: 'Invalid authentication method',
-        message: 'Use Clerk session to revoke API keys'
+        message: 'Use Clerk session (or local auth in local mode) to revoke API keys'
       }),
       {
         status: 403,
@@ -531,16 +551,17 @@ export async function handleRevokeApiKey(request, env, keyId) {
  */
 export async function handleRevealApiKey(request, env, keyId) {
   const authResult = await authenticate(request, env);
+  const isLocalMode = env.ENVIRONMENT === 'local';
 
   // Require Clerk session (API keys cannot reveal other keys)
   const authError = requireAuth(authResult);
   if (authError) return authError;
 
-  if (authResult.user.authMethod !== 'clerk') {
+  if (authResult.user.authMethod !== 'clerk' && !(isLocalMode && authResult.user.authMethod === 'local')) {
     return new Response(
       JSON.stringify({
         error: 'Invalid authentication method',
-        message: 'API keys cannot reveal other API keys. Use Clerk session.'
+        message: 'API keys cannot reveal other API keys. Use Clerk session (or local auth in local mode).'
       }),
       {
         status: 403,
@@ -550,42 +571,44 @@ export async function handleRevealApiKey(request, env, keyId) {
   }
 
   // Verify session is fresh (authenticated within last 5 minutes)
-  try {
-    if (!env.CLERK_SECRET_KEY) {
-      throw new Error('CLERK_SECRET_KEY not configured');
-    }
+  if (!isLocalMode) {
+    try {
+      if (!env.CLERK_SECRET_KEY) {
+        throw new Error('CLERK_SECRET_KEY not configured');
+      }
 
-    const clerkClient = createClerkClient({
-      secretKey: env.CLERK_SECRET_KEY
-    });
+      const clerkClient = createClerkClient({
+        secretKey: env.CLERK_SECRET_KEY
+      });
 
-    const sessionId = authResult.user.sessionId;
-    const session = await clerkClient.sessions.getSession(sessionId);
+      const sessionId = authResult.user.sessionId;
+      const session = await clerkClient.sessions.getSession(sessionId);
 
-    // Check if session is fresh
-    if (!isSessionFresh(session, 5)) {
+      // Check if session is fresh
+      if (!isSessionFresh(session, 5)) {
+        return new Response(
+          JSON.stringify({
+            error: 'FRESH_AUTH_REQUIRED',
+            message: 'This operation requires a fresh authentication session (authenticated within the last 5 minutes). Please re-authenticate.'
+          }),
+          {
+            status: 403,
+            headers: { 'content-type': 'application/json' }
+          }
+        );
+      }
+    } catch (error) {
       return new Response(
         JSON.stringify({
-          error: 'FRESH_AUTH_REQUIRED',
-          message: 'This operation requires a fresh authentication session (authenticated within the last 5 minutes). Please re-authenticate.'
+          error: 'Session verification failed',
+          message: error.message
         }),
         {
-          status: 403,
+          status: 500,
           headers: { 'content-type': 'application/json' }
         }
       );
     }
-  } catch (error) {
-    return new Response(
-      JSON.stringify({
-        error: 'Session verification failed',
-        message: error.message
-      }),
-      {
-        status: 500,
-        headers: { 'content-type': 'application/json' }
-      }
-    );
   }
 
   // Get encrypted key from UserProfile DO (includes rate limiting)
@@ -612,7 +635,7 @@ export async function handleRevealApiKey(request, env, keyId) {
   const keyData = await response.json();
 
   // Decrypt the API key
-  if (!env.API_KEY_ENCRYPTION_KEY) {
+  if (!isLocalMode && !env.API_KEY_ENCRYPTION_KEY) {
     return new Response(
       JSON.stringify({
         error: 'Encryption key not configured',
@@ -626,7 +649,9 @@ export async function handleRevealApiKey(request, env, keyId) {
   }
 
   try {
-    const apiKey = await decryptApiKey(keyData.key_encrypted, env.API_KEY_ENCRYPTION_KEY);
+    const apiKey = isLocalMode
+      ? keyData.key_encrypted
+      : await decryptApiKey(keyData.key_encrypted, env.API_KEY_ENCRYPTION_KEY);
 
     return new Response(
       JSON.stringify({
@@ -668,16 +693,17 @@ export async function handleRevealApiKey(request, env, keyId) {
  */
 export async function handleUpdateApiKey(request, env, keyId) {
   const authResult = await authenticate(request, env);
+  const isLocalMode = env.ENVIRONMENT === 'local';
 
   // Require Clerk session (API keys cannot update themselves)
   const authError = requireAuth(authResult);
   if (authError) return authError;
 
-  if (authResult.user.authMethod !== 'clerk') {
+  if (authResult.user.authMethod !== 'clerk' && !(isLocalMode && authResult.user.authMethod === 'local')) {
     return new Response(
       JSON.stringify({
         error: 'Invalid authentication method',
-        message: 'API keys cannot update other API keys. Use Clerk session.'
+        message: 'API keys cannot update other API keys. Use Clerk session (or local auth in local mode).'
       }),
       {
         status: 403,
@@ -687,42 +713,44 @@ export async function handleUpdateApiKey(request, env, keyId) {
   }
 
   // Verify session is fresh (authenticated within last 5 minutes)
-  try {
-    if (!env.CLERK_SECRET_KEY) {
-      throw new Error('CLERK_SECRET_KEY not configured');
-    }
+  if (!isLocalMode) {
+    try {
+      if (!env.CLERK_SECRET_KEY) {
+        throw new Error('CLERK_SECRET_KEY not configured');
+      }
 
-    const clerkClient = createClerkClient({
-      secretKey: env.CLERK_SECRET_KEY
-    });
+      const clerkClient = createClerkClient({
+        secretKey: env.CLERK_SECRET_KEY
+      });
 
-    const sessionId = authResult.user.sessionId;
-    const session = await clerkClient.sessions.getSession(sessionId);
+      const sessionId = authResult.user.sessionId;
+      const session = await clerkClient.sessions.getSession(sessionId);
 
-    // Check if session is fresh (5 minutes)
-    if (!isSessionFresh(session, 5)) {
+      // Check if session is fresh (5 minutes)
+      if (!isSessionFresh(session, 5)) {
+        return new Response(
+          JSON.stringify({
+            error: 'FRESH_AUTH_REQUIRED',
+            message: 'This operation requires a fresh authentication session (authenticated within the last 5 minutes). Please re-authenticate.'
+          }),
+          {
+            status: 403,
+            headers: { 'content-type': 'application/json' }
+          }
+        );
+      }
+    } catch (error) {
       return new Response(
         JSON.stringify({
-          error: 'FRESH_AUTH_REQUIRED',
-          message: 'This operation requires a fresh authentication session (authenticated within the last 5 minutes). Please re-authenticate.'
+          error: 'Session verification failed',
+          message: error.message
         }),
         {
-          status: 403,
+          status: 500,
           headers: { 'content-type': 'application/json' }
         }
       );
     }
-  } catch (error) {
-    return new Response(
-      JSON.stringify({
-        error: 'Session verification failed',
-        message: error.message
-      }),
-      {
-        status: 500,
-        headers: { 'content-type': 'application/json' }
-      }
-    );
   }
 
   // Parse request body

--- a/src/api/local-payments.js
+++ b/src/api/local-payments.js
@@ -1,0 +1,144 @@
+/**
+ * Local Payments API Handlers
+ * Mock payment flow for local development (no Stripe).
+ */
+
+import { authenticate } from '../auth/middleware.js';
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+export async function handleLocalDepositUnavailable() {
+  return jsonResponse(
+    {
+      error: 'Stripe disabled in local mode',
+      message: 'Use /api/balance/dev-deposit to add funds while running locally.'
+    },
+    400
+  );
+}
+
+export async function handleLocalDonationUnavailable() {
+  return jsonResponse(
+    {
+      error: 'Stripe disabled in local mode',
+      message: 'Donations are disabled in local mode.'
+    },
+    400
+  );
+}
+
+export async function handleLocalDevDeposit(request, env) {
+  if (env.ENVIRONMENT !== 'local') {
+    return jsonResponse(
+      {
+        error: 'Endpoint unavailable',
+        message: 'Dev deposits are only available in local mode.'
+      },
+      404
+    );
+  }
+
+  const authResult = await authenticate(request, env);
+
+  if (!authResult.authenticated) {
+    return jsonResponse(
+      {
+        error: 'Unauthorized',
+        message: 'Authentication required'
+      },
+      401
+    );
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return jsonResponse(
+      {
+        error: 'Invalid request',
+        message: 'Request body must be valid JSON'
+      },
+      400
+    );
+  }
+
+  const amount_cents = body.amount_cents;
+
+  if (!Number.isInteger(amount_cents) || amount_cents <= 0) {
+    return jsonResponse(
+      {
+        error: 'Invalid amount',
+        message: 'Amount must be a positive integer of cents'
+      },
+      400
+    );
+  }
+
+  const userId = authResult.user.userId;
+  const userProfileId = env.USER_PROFILES.idFromName(userId);
+  const userProfileStub = env.USER_PROFILES.get(userProfileId);
+
+  const balanceResponse = await userProfileStub.fetch(
+    new Request('http://internal/balance')
+  );
+
+  if (!balanceResponse.ok) {
+    return jsonResponse(
+      {
+        error: 'Profile not found',
+        message: 'User profile is missing'
+      },
+      404
+    );
+  }
+
+  const balanceData = await balanceResponse.json();
+  const balance_before = balanceData.balance_cents;
+
+  const depositResponse = await userProfileStub.fetch(
+    new Request('http://internal/balance/deposit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ amount_cents })
+    })
+  );
+
+  if (!depositResponse.ok) {
+    const error = await depositResponse.json();
+    return jsonResponse(error, depositResponse.status);
+  }
+
+  const depositData = await depositResponse.json();
+
+  const transactionId = crypto.randomUUID();
+  const paymentRecordId = env.PAYMENT_RECORDS.idFromName(userId);
+  const paymentRecordStub = env.PAYMENT_RECORDS.get(paymentRecordId);
+
+  await paymentRecordStub.fetch(
+    new Request('http://internal/transaction', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        transaction_id: transactionId,
+        type: 'deposit',
+        user_id: userId,
+        amount_cents: amount_cents,
+        balance_before_cents: balance_before,
+        balance_after_cents: depositData.balance_after_cents
+      })
+    })
+  );
+
+  return jsonResponse({
+    transaction_id: transactionId,
+    amount_cents: amount_cents,
+    balance_before_cents: balance_before,
+    balance_after_cents: depositData.balance_after_cents
+  });
+}

--- a/src/api/payments.js
+++ b/src/api/payments.js
@@ -5,6 +5,7 @@
 
 import Stripe from 'stripe';
 import { authenticate } from '../auth/middleware.js';
+import { handleLocalDepositUnavailable, handleLocalDonationUnavailable } from './local-payments.js';
 import { 
   calculateStripeFees, 
   calculateTotalWithFees,
@@ -18,6 +19,10 @@ import {
  * Create a Stripe checkout session for depositing funds
  */
 export async function handleCreateDeposit(request, env) {
+  if (env.ENVIRONMENT === 'local') {
+    return handleLocalDepositUnavailable();
+  }
+
   const authResult = await authenticate(request, env);
   
   if (!authResult.authenticated) {
@@ -158,6 +163,19 @@ export async function handleCreateDeposit(request, env) {
  * Handle Stripe webhook events
  */
 export async function handleStripeWebhook(request, env) {
+  if (env.ENVIRONMENT === 'local') {
+    return new Response(
+      JSON.stringify({
+        error: 'Stripe disabled in local mode',
+        message: 'Stripe webhooks are not processed in local mode.'
+      }),
+      {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      }
+    );
+  }
+
   try {
     const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
       apiVersion: '2024-11-20.acacia'
@@ -395,6 +413,10 @@ async function handleCheckoutSessionCompleted(session, env) {
  * Create a Stripe checkout session for donating to a CID (anonymous allowed)
  */
 export async function handleCreateDonation(request, env, cid) {
+  if (env.ENVIRONMENT === 'local') {
+    return handleLocalDonationUnavailable();
+  }
+
   try {
     const data = await request.json();
     const amount_cents = data.amount_cents;

--- a/src/auth/local-auth.js
+++ b/src/auth/local-auth.js
@@ -1,0 +1,61 @@
+/**
+ * Local Authentication Helpers
+ * Used for fully local development (no external auth providers).
+ */
+
+const LOCAL_USER_ID_MAX_LENGTH = 256;
+const LOCAL_STARTING_BALANCE_CENTS = 1000;
+
+export function validateLocalUserId(rawUserId) {
+  if (typeof rawUserId !== 'string') {
+    return { valid: false, reason: 'missing' };
+  }
+
+  const userId = rawUserId.trim();
+  if (!userId) {
+    return { valid: false, reason: 'missing' };
+  }
+
+  if (userId.length > LOCAL_USER_ID_MAX_LENGTH) {
+    return { valid: false, reason: 'too_long' };
+  }
+
+  return { valid: true, userId };
+}
+
+export async function getOrCreateLocalProfile(env, userId) {
+  const userProfileId = env.USER_PROFILES.idFromName(userId);
+  const userProfileStub = env.USER_PROFILES.get(userProfileId);
+
+  const profileResponse = await userProfileStub.fetch(
+    new Request('http://internal/profile', { method: 'GET' })
+  );
+
+  if (profileResponse.ok) {
+    const profile = await profileResponse.json();
+    return { profile, created: false };
+  }
+
+  if (profileResponse.status !== 404) {
+    throw new Error('Failed to load user profile');
+  }
+
+  const createResponse = await userProfileStub.fetch(
+    new Request('http://internal/profile', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        user_id: userId,
+        providers: ['local'],
+        initial_balance_cents: LOCAL_STARTING_BALANCE_CENTS
+      })
+    })
+  );
+
+  if (!createResponse.ok) {
+    throw new Error('Failed to create local user profile');
+  }
+
+  const profile = await createResponse.json();
+  return { profile, created: true };
+}

--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -5,6 +5,7 @@
 
 import { verifyToken } from '@clerk/backend';
 import { hashApiKey, validateApiKeyFormat } from './utils.js';
+import { getOrCreateLocalProfile, validateLocalUserId } from './local-auth.js';
 
 // Error codes for authentication failures
 export const AUTH_ERROR_CODES = {
@@ -56,6 +57,8 @@ function extractAuth(request) {
       return { type: 'clerk', value };
     } else if (normalizedScheme === 'apikey') {
       return { type: 'apikey', value };
+    } else if (normalizedScheme === 'localdev') {
+      return { type: 'local', value };
     } else {
       return { type: 'invalid', value: null };
     }
@@ -282,6 +285,7 @@ function checkRateLimit(identifier, limit) {
  */
 export async function authenticate(request, env) {
   const auth = extractAuth(request);
+  const isLocalMode = env.ENVIRONMENT === 'local';
 
   // No authentication provided
   if (auth.type === 'none') {
@@ -301,8 +305,65 @@ export async function authenticate(request, env) {
     };
   }
 
+  // Local development authentication
+  if (auth.type === 'local') {
+    if (!isLocalMode) {
+      return {
+        authenticated: false,
+        user: null,
+        error: AUTH_ERROR_CODES.AUTH_INVALID_FORMAT
+      };
+    }
+
+    const validation = validateLocalUserId(auth.value);
+    if (!validation.valid) {
+      return {
+        authenticated: false,
+        user: null,
+        error: AUTH_ERROR_CODES.AUTH_INVALID_FORMAT
+      };
+    }
+
+    try {
+      const { profile } = await getOrCreateLocalProfile(env, validation.userId);
+
+      if (profile.deleted_at) {
+        return {
+          authenticated: false,
+          user: null,
+          error: AUTH_ERROR_CODES.AUTH_USER_DELETED
+        };
+      }
+
+      return {
+        authenticated: true,
+        user: {
+          userId: profile.user_id,
+          sessionId: null,
+          authMethod: 'local',
+          profile
+        },
+        error: null
+      };
+    } catch (error) {
+      return {
+        authenticated: false,
+        user: null,
+        error: AUTH_ERROR_CODES.AUTH_INVALID_FORMAT
+      };
+    }
+  }
+
   // Clerk JWT token
   if (auth.type === 'clerk') {
+    if (isLocalMode) {
+      return {
+        authenticated: false,
+        user: null,
+        error: AUTH_ERROR_CODES.AUTH_INVALID_FORMAT
+      };
+    }
+
     const validation = await validateClerkToken(auth.value, env);
     if (!validation.valid) {
       return {

--- a/src/durable-objects/user-profile.js
+++ b/src/durable-objects/user-profile.js
@@ -151,6 +151,10 @@ export class UserProfile {
       );
     }
 
+    const initialBalance = Number.isInteger(data.initial_balance_cents) && data.initial_balance_cents > 0
+      ? data.initial_balance_cents
+      : 0;
+
     const profile = {
       user_id: data.user_id,
       providers: data.providers || [],
@@ -159,8 +163,8 @@ export class UserProfile {
       deleted_at: null,
       api_keys: [],
       uploads: [],
-      balance_cents: 0,
-      total_deposited_cents: 0,
+      balance_cents: initialBalance,
+      total_deposited_cents: initialBalance,
       total_spent_cents: 0
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ import {
   handleCalculateRetention,
   handleCreateDonation
 } from './api/payments.js';
+import { handleLocalDevDeposit } from './api/local-payments.js';
 
 import {
   handleUploadContent,
@@ -52,7 +53,7 @@ import { handleGetUserUploads } from './api/user.js';
 import { applyRateLimit, authenticate } from './auth/middleware.js';
 
 // Configuration constants
-const VALID_ENVIRONMENTS = ['development', 'production'];
+const VALID_ENVIRONMENTS = ['development', 'production', 'local'];
 const VALID_LOG_LEVELS = ['debug', 'info', 'warn', 'error'];
 const HEALTH_CHECK_ID = 'health-check';
 const GIT_SHA_PLACEHOLDER = 'unknown';
@@ -255,6 +256,10 @@ function handleApiRoutes(url, request, env) {
     return handleCreateDeposit(request, env);
   }
 
+  if (url.pathname === '/api/balance/dev-deposit' && request.method === 'POST') {
+    return handleLocalDevDeposit(request, env);
+  }
+
   // Payment calculation endpoint (public)
   if (url.pathname === '/api/payments/calculate' && request.method === 'POST') {
     return handleCalculateRetention(request, env);
@@ -376,8 +381,11 @@ function handleRoot(env) {
  * Returns non-secret configuration needed by the frontend
  */
 function handleConfig(env) {
+  const isLocalMode = env.ENVIRONMENT === 'local';
   const config = {
-    clerkPublishableKey: env.CLERK_PUBLISHABLE_KEY || null
+    clerkPublishableKey: isLocalMode ? null : (env.CLERK_PUBLISHABLE_KEY || null),
+    isLocalMode,
+    authMode: isLocalMode ? 'local' : 'clerk'
   };
 
   return new Response(JSON.stringify(config), {
@@ -607,6 +615,17 @@ async function checkR2Buckets(env) {
  * Check Clerk integration health
  */
 async function checkClerk(env) {
+  if (env.ENVIRONMENT === 'local') {
+    return {
+      status: 'operational',
+      message: 'Clerk disabled in local mode',
+      details: {
+        secretKeyConfigured: false,
+        publishableKeyConfigured: false
+      }
+    };
+  }
+
   const checks = {
     secretKeyConfigured: false,
     publishableKeyConfigured: false
@@ -642,6 +661,17 @@ async function checkClerk(env) {
  * Check Stripe integration health
  */
 async function checkStripe(env) {
+  if (env.ENVIRONMENT === 'local') {
+    return {
+      status: 'operational',
+      message: 'Stripe disabled in local mode',
+      details: {
+        secretKeyConfigured: false,
+        webhookSecretConfigured: false
+      }
+    };
+  }
+
   const checks = {
     secretKeyConfigured: false,
     webhookSecretConfigured: false

--- a/todo/running_fully_local.md
+++ b/todo/running_fully_local.md
@@ -322,10 +322,10 @@ The implementation is complete when:
 
 ## Status
 
-- [ ] Phase 1: Local Development Configuration
-- [ ] Phase 2: Mock Authentication System
-- [ ] Phase 3: Mock Payment System
-- [ ] Phase 4: API Config Endpoint Enhancement
-- [ ] Phase 5: Local Setup Documentation
+- [x] Phase 1: Local Development Configuration
+- [x] Phase 2: Mock Authentication System
+- [x] Phase 3: Mock Payment System
+- [x] Phase 4: API Config Endpoint Enhancement
+- [x] Phase 5: Local Setup Documentation
 - [ ] All tests passing
-- [ ] Documentation complete
+- [x] Documentation complete

--- a/wrangler.local.toml
+++ b/wrangler.local.toml
@@ -1,0 +1,65 @@
+name = "hashbin-worker-local"
+main = "src/index.js"
+compatibility_date = "2024-01-01"
+
+# Static assets (frontend files)
+[assets]
+directory = "./frontend"
+binding = "ASSETS"
+
+# Local development environment variables
+[vars]
+ENVIRONMENT = "local"
+LOG_LEVEL = "debug"
+
+# Local dev does not bind to production routes
+workers_dev = true
+
+# Durable Objects bindings
+[[durable_objects.bindings]]
+name = "CONTENT_METADATA"
+class_name = "ContentMetadata"
+script_name = "hashbin-worker-local"
+
+[[durable_objects.bindings]]
+name = "USER_PROFILES"
+class_name = "UserProfile"
+script_name = "hashbin-worker-local"
+
+[[durable_objects.bindings]]
+name = "PAYMENT_RECORDS"
+class_name = "PaymentRecord"
+script_name = "hashbin-worker-local"
+
+[[durable_objects.bindings]]
+name = "CONTEST_RECORDS"
+class_name = "ContestRecord"
+script_name = "hashbin-worker-local"
+
+[[durable_objects.bindings]]
+name = "MESSAGE_THREADS"
+class_name = "MessageThread"
+script_name = "hashbin-worker-local"
+
+[[durable_objects.bindings]]
+name = "KEY_REGISTRY"
+class_name = "KeyRegistry"
+script_name = "hashbin-worker-local"
+
+# R2 bucket bindings (local emulation)
+[[r2_buckets]]
+binding = "CONTENT_BUCKET"
+bucket_name = "hashbin-content-local"
+
+[[r2_buckets]]
+binding = "BACKUP_BUCKET"
+bucket_name = "hashbin-backups-local"
+
+# Durable Objects migrations
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ContentMetadata", "UserProfile", "PaymentRecord", "ContestRecord", "MessageThread"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["KeyRegistry"]


### PR DESCRIPTION
### Motivation

- Enable running the entire stack locally without Clerk, Stripe, or production Cloudflare services so developers can iterate and test offline.
- Provide a deterministic local auth flow and a mock payments path to exercise end-to-end workflows (login → deposit → upload) during development.
- Surface server-driven detection to the frontend so UI can switch between production and local modes.

### Description

- Add `wrangler.local.toml` and `npm run dev:local` to run a local Wrangler configuration with `ENVIRONMENT = "local"` and local R2/Durable Object bindings.
- Implement backend local auth helpers and integration: `src/auth/local-auth.js`, wired into `src/auth/middleware.js` to accept `Authorization: LocalDev <user_id>` and auto-create a `UserProfile` with a starting balance.
- Add mock payments handlers: `src/api/local-payments.js` and route `/api/balance/dev-deposit`; `src/api/payments.js` is updated to disable Stripe paths in local mode.
- Expose local mode in the API config via `handleConfig()` in `src/index.js` (`isLocalMode` and `authMode`) and update health checks to reflect disabled Clerk/Stripe in local mode.
- Frontend: add `frontend/js/auth-loader.js` to dynamically load either the Clerk auth module or `frontend/js/local-auth.js`, update usages (`app.js`, `auth-gate.js`, `utils.js`, `upload.js`, `deposit.js`) to use the loader, and implement a simple local sign-in UI and headers for API requests.
- Deposit page: detect local mode and show a direct "Add Funds" flow that calls `/api/balance/dev-deposit` instead of Stripe checkout, with a small minimum for local testing.
- Durable object change: `UserProfile.createProfile` accepts `initial_balance_cents` so new local users can start with a test balance.
- Docs and tooling: add `docs/local-development.md`, update `README.md` and `frontend/README.md`, add `scripts/test-local-mode.sh`, and mark progress in `todo/running_fully_local.md`.

### Testing

- Started the local worker with `npm run dev:local` and Wrangler reported the service as Ready on `http://localhost:8787`, indicating the local dev server launched successfully.
- Attempted automated browser checks with Playwright to load `/deposit` and `/health`, but the Playwright navigation failed with `net::ERR_EMPTY_RESPONSE` (Playwright run failed); this indicates flakiness in the headless navigation step during the run and requires follow-up investigation.
- Performed a quick HTTP check with `curl -I http://localhost:8787/deposit.html` which returned `307 Temporary Redirect`, confirming the worker responded; no full end-to-end automated test suite was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696bee804c34833199085a56866b8ddb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fully offline local development mode with local authentication via username
  * Enabled local deposit testing without external payment services
  * Updated authentication system to support local-only workflows

* **Documentation**
  * Introduced comprehensive local development guide with setup steps and debugging tips
  * Updated Quick Start section with local development workflow and helpful endpoints

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->