### PR TITLE
Improve cache purge workflow diagnostics

### DIFF
--- a/scripts/purge-cloudflare-cache.sh
+++ b/scripts/purge-cloudflare-cache.sh
@@ -76,6 +76,29 @@ if [ -z "$CLOUDFLARE_ZONE_ID" ]; then
     exit 1
 fi
 
+# Function to check if API response indicates success
+# Handles both "success":true and "success": true (with/without space)
+check_api_success() {
+    local body="$1"
+    # Use grep with regex to handle optional whitespace around the colon
+    echo "$body" | grep -qE '"success"\s*:\s*true'
+}
+
+# Function to extract error messages from API response
+extract_errors() {
+    local body="$1"
+    # Try to extract errors array content if jq is available
+    if command -v jq &> /dev/null; then
+        local errors=$(echo "$body" | jq -r '.errors[]?.message // empty' 2>/dev/null)
+        if [ -n "$errors" ]; then
+            echo "$errors"
+            return
+        fi
+    fi
+    # Fallback: show raw errors field
+    echo "$body" | grep -oE '"errors"\s*:\s*\[[^]]*\]' || echo "Unable to extract errors"
+}
+
 # Function to make API request with retry logic
 purge_cache() {
     local data="$1"
@@ -95,25 +118,58 @@ purge_cache() {
 
         if [ "$HTTP_CODE" = "200" ]; then
             # Check if the API returned success
-            if echo "$BODY" | grep -q '"success":true'; then
+            if check_api_success "$BODY"; then
+                # Store response for success message
+                LAST_RESPONSE_BODY="$BODY"
                 return 0
+            else
+                echo -e "${YELLOW}HTTP 200 but API reported failure${NC}"
+                echo "Errors: $(extract_errors "$BODY")"
             fi
+        elif [ "$HTTP_CODE" = "429" ]; then
+            # Rate limiting
+            echo -e "${YELLOW}Rate limited (HTTP 429). Waiting before retry...${NC}"
+            sleep $((RETRY_DELAY * attempt * 2))
+            attempt=$((attempt + 1))
+            continue
+        else
+            echo -e "${YELLOW}HTTP $HTTP_CODE - Request failed${NC}"
         fi
 
-        # Check for rate limiting
-        if [ "$HTTP_CODE" = "429" ]; then
-            echo -e "${YELLOW}Rate limited. Waiting before retry...${NC}"
-            sleep $((RETRY_DELAY * attempt * 2))
-        else
+        # For non-rate-limit failures, add delay before retry
+        if [ "$HTTP_CODE" != "429" ]; then
             sleep $((RETRY_DELAY * attempt))
         fi
 
         attempt=$((attempt + 1))
     done
 
+    echo ""
+    echo -e "${RED}============================================${NC}"
     echo -e "${RED}Failed after $MAX_RETRIES attempts${NC}"
-    echo "HTTP Status: $HTTP_CODE"
-    echo "Response: $BODY"
+    echo -e "${RED}============================================${NC}"
+    echo ""
+    echo "Diagnostic Information:"
+    echo "  HTTP Status: $HTTP_CODE"
+    echo "  Expected: 200 with success:true"
+    echo ""
+    echo "API Response:"
+    echo "$BODY"
+    echo ""
+    echo "Troubleshooting:"
+    if [ "$HTTP_CODE" = "403" ]; then
+        echo "  - Check that CLOUDFLARE_API_TOKEN has 'Zone.Cache Purge' permission"
+        echo "  - Verify the token is not expired"
+    elif [ "$HTTP_CODE" = "400" ]; then
+        echo "  - Check that CLOUDFLARE_ZONE_ID is correct"
+        echo "  - Verify the request payload format"
+    elif [ "$HTTP_CODE" = "401" ]; then
+        echo "  - Check that CLOUDFLARE_API_TOKEN is valid"
+        echo "  - Token may have been revoked or expired"
+    else
+        echo "  - Review the API response above for error details"
+        echo "  - Check Cloudflare API status: https://www.cloudflarestatus.com/"
+    fi
     return 1
 }
 
@@ -140,7 +196,15 @@ if [ -n "$PURGE_URLS" ]; then
     echo ""
 
     if purge_cache "$DATA"; then
-        echo -e "${GREEN}Successfully purged specified URLs${NC}"
+        echo ""
+        echo -e "${GREEN}✓ Successfully purged specified URLs${NC}"
+        # Extract and display purge ID if jq is available
+        if command -v jq &> /dev/null && [ -n "$LAST_RESPONSE_BODY" ]; then
+            PURGE_ID=$(echo "$LAST_RESPONSE_BODY" | jq -r '.result.id // empty' 2>/dev/null)
+            if [ -n "$PURGE_ID" ]; then
+                echo "  Purge ID: $PURGE_ID"
+            fi
+        fi
     else
         echo -e "${RED}Failed to purge specified URLs${NC}"
         exit 1
@@ -154,7 +218,15 @@ else
     DATA='{"purge_everything":true}'
 
     if purge_cache "$DATA"; then
-        echo -e "${GREEN}Successfully purged entire cache${NC}"
+        echo ""
+        echo -e "${GREEN}✓ Successfully purged entire cache${NC}"
+        # Extract and display purge ID if jq is available
+        if command -v jq &> /dev/null && [ -n "$LAST_RESPONSE_BODY" ]; then
+            PURGE_ID=$(echo "$LAST_RESPONSE_BODY" | jq -r '.result.id // empty' 2>/dev/null)
+            if [ -n "$PURGE_ID" ]; then
+                echo "  Purge ID: $PURGE_ID"
+            fi
+        fi
     else
         echo -e "${RED}Failed to purge cache${NC}"
         exit 1


### PR DESCRIPTION
The script was incorrectly failing even when Cloudflare API returned success because the grep pattern '"success":true' didn't match the actual response format '"success": true' (with a space).

Changes:
- Fix success check to handle whitespace variations in JSON
- Add detailed diagnostic info on failure (HTTP status, troubleshooting tips)
- Display purge ID on success when jq is available
- Extract and show error messages from failed API responses
- Add context-specific troubleshooting guidance for 401/403/400 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling with detailed diagnostic messages and tailored troubleshooting hints when cache purge fails
  * Added explicit rate-limit handling with improved retry logic
  * Improved API response parsing with flexible whitespace matching for success validation
  * Display Purge IDs on successful cache purge operations when available for verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->