### PR TITLE
Fix deployment pipeline not updating version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,11 +54,21 @@ jobs:
         run: |
           GIT_SHA=$(git rev-parse HEAD)
           echo "Git SHA: $GIT_SHA"
-          
+
           # Inject SHA into HTML files
           bash scripts/inject-git-sha.sh "$GIT_SHA"
           echo "✅ Git SHA injected into HTML files"
-          
+
+      - name: Inject git SHA into worker source code
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          echo "Git SHA: $GIT_SHA"
+
+          # Inject SHA into worker source code
+          # This ensures code changes with each commit, forcing wrangler to redeploy
+          bash scripts/inject-git-sha-code.sh "$GIT_SHA"
+          echo "✅ Git SHA injected into source code"
+
       - name: Create R2 buckets
         run: |
           create_bucket() {

--- a/scripts/inject-git-sha-code.sh
+++ b/scripts/inject-git-sha-code.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Inject git SHA directly into source code before deployment
+#
+# This script replaces the placeholder '__DEPLOY_GIT_SHA__' in src/index.js
+# with the actual git SHA. This ensures the code changes with each commit,
+# forcing wrangler to upload new worker code.
+#
+# Usage:
+#   ./scripts/inject-git-sha-code.sh [GIT_SHA]
+#
+# If GIT_SHA is not provided, it will be determined from git rev-parse HEAD
+#
+
+set -e
+
+# Get git SHA from argument or git command
+GIT_SHA="${1:-$(git rev-parse HEAD)}"
+
+if [ -z "$GIT_SHA" ]; then
+    echo "ERROR: Could not determine git SHA"
+    exit 1
+fi
+
+SOURCE_FILE="src/index.js"
+PLACEHOLDER="__DEPLOY_GIT_SHA__"
+
+echo "Injecting git SHA into source code..."
+echo "  Git SHA: $GIT_SHA"
+echo "  File: $SOURCE_FILE"
+
+# Check if the file exists
+if [ ! -f "$SOURCE_FILE" ]; then
+    echo "ERROR: Source file not found: $SOURCE_FILE"
+    exit 1
+fi
+
+# Check if the placeholder exists (either the original or a previously injected SHA)
+if grep -q "BUNDLED_GIT_SHA = " "$SOURCE_FILE"; then
+    # Replace the BUNDLED_GIT_SHA line with the new SHA
+    sed -i "s/const BUNDLED_GIT_SHA = '[^']*';/const BUNDLED_GIT_SHA = '$GIT_SHA';/" "$SOURCE_FILE"
+
+    # Verify the replacement
+    if grep -q "BUNDLED_GIT_SHA = '$GIT_SHA'" "$SOURCE_FILE"; then
+        echo "SUCCESS: Git SHA injected into source code"
+    else
+        echo "ERROR: Failed to inject git SHA"
+        exit 1
+    fi
+else
+    echo "ERROR: BUNDLED_GIT_SHA constant not found in $SOURCE_FILE"
+    exit 1
+fi
+
+# Show the updated line for verification
+echo ""
+echo "Updated line:"
+grep "BUNDLED_GIT_SHA" "$SOURCE_FILE"

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,10 @@ const VALID_LOG_LEVELS = ['debug', 'info', 'warn', 'error'];
 const HEALTH_CHECK_ID = 'health-check';
 const GIT_SHA_PLACEHOLDER = 'unknown';
 
+// Git SHA embedded at build time - replaced during deployment
+// This constant forces code changes on each deploy, ensuring wrangler uploads new code
+const BUNDLED_GIT_SHA = '__DEPLOY_GIT_SHA__';
+
 // Static paths that should not be matched as CIDs
 // These paths are served by the ASSETS binding (frontend files)
 // Note: In a larger application, consider moving this to a configuration file
@@ -360,13 +364,15 @@ async function withGitShaComment(response, env) {
     return response;
   }
 
-  const gitSha = env.GIT_SHA || GIT_SHA_PLACEHOLDER;
+  // Prefer bundled SHA (embedded at build time), fall back to secret, then placeholder
+  const bundledShaIsValid = BUNDLED_GIT_SHA && BUNDLED_GIT_SHA !== '__DEPLOY_GIT_SHA__';
+  const gitSha = bundledShaIsValid ? BUNDLED_GIT_SHA : (env.GIT_SHA || GIT_SHA_PLACEHOLDER);
   const html = await response.text();
   const updatedHtml = injectGitShaIntoHtml(html, gitSha);
   const headers = new Headers(response.headers);
   headers.delete('content-length');
   headers.set('x-git-sha', gitSha);
-  headers.set('x-git-sha-present', String(Boolean(env.GIT_SHA)));
+  headers.set('x-git-sha-present', String(bundledShaIsValid || Boolean(env.GIT_SHA)));
 
   return new Response(updatedHtml, {
     status: response.status,
@@ -445,16 +451,20 @@ async function handleHealth(env) {
     overallStatus = 'degraded';
   }
 
-  if (!env.GIT_SHA) {
-    console.warn('Health check: GIT_SHA secret is not configured.');
+  // Determine git SHA: prefer bundled value (embedded at build time), fall back to secret, then placeholder
+  const bundledShaIsValid = BUNDLED_GIT_SHA && BUNDLED_GIT_SHA !== '__DEPLOY_GIT_SHA__';
+  const effectiveGitSha = bundledShaIsValid ? BUNDLED_GIT_SHA : (env.GIT_SHA || GIT_SHA_PLACEHOLDER);
+
+  if (!bundledShaIsValid && !env.GIT_SHA) {
+    console.warn('Health check: Neither BUNDLED_GIT_SHA nor GIT_SHA secret is configured.');
   }
 
   const health = {
     status: overallStatus,
     timestamp: new Date().toISOString(),
     environment: env.ENVIRONMENT || 'unknown',
-    gitSha: env.GIT_SHA || GIT_SHA_PLACEHOLDER,
-    gitShaPresent: Boolean(env.GIT_SHA),
+    gitSha: effectiveGitSha,
+    gitShaPresent: bundledShaIsValid || Boolean(env.GIT_SHA),
     checks: checks,
     summary: {
       total: Object.keys(checks).length,
@@ -471,8 +481,8 @@ async function handleHealth(env) {
     headers: {
       'content-type': 'application/json',
       'access-control-allow-origin': '*',
-      'x-git-sha': env.GIT_SHA || GIT_SHA_PLACEHOLDER,
-      'x-git-sha-present': String(Boolean(env.GIT_SHA))
+      'x-git-sha': effectiveGitSha,
+      'x-git-sha-present': String(bundledShaIsValid || Boolean(env.GIT_SHA))
     }
   });
 }


### PR DESCRIPTION
The deployment was failing because changing from `wrangler deploy --var` to `wrangler secret put` + `wrangler deploy` broke the deployment process. Secrets are stored separately from worker code, so updating a secret doesn't trigger a code redeployment. When wrangler deploy runs with no code changes, it doesn't upload new worker code.

This fix:
- Adds BUNDLED_GIT_SHA constant to src/index.js with a placeholder
- Creates inject-git-sha-code.sh script to replace the placeholder
- Updates deploy.yml to inject the SHA before wrangler deploy
- Updates health endpoint and HTML injection to use bundled SHA

The bundled SHA ensures each commit produces different code, forcing wrangler to upload the new worker version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment process with Git SHA integration to ensure consistent version tracking and reliable redeploys across all application components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->