### PR TITLE
Fix worker name to match Cloudflare routes

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "hashbin-worker"
+name = "hashbin-worker-prod"
 main = "src/index.js"
 compatibility_date = "2024-12-01"
 
@@ -30,32 +30,32 @@ workers_dev = true
 [[durable_objects.bindings]]
 name = "CONTENT_METADATA"
 class_name = "ContentMetadata"
-script_name = "hashbin-worker"
+script_name = "hashbin-worker-prod"
 
 [[durable_objects.bindings]]
 name = "USER_PROFILES"
 class_name = "UserProfile"
-script_name = "hashbin-worker"
+script_name = "hashbin-worker-prod"
 
 [[durable_objects.bindings]]
 name = "PAYMENT_RECORDS"
 class_name = "PaymentRecord"
-script_name = "hashbin-worker"
+script_name = "hashbin-worker-prod"
 
 [[durable_objects.bindings]]
 name = "CONTEST_RECORDS"
 class_name = "ContestRecord"
-script_name = "hashbin-worker"
+script_name = "hashbin-worker-prod"
 
 [[durable_objects.bindings]]
 name = "MESSAGE_THREADS"
 class_name = "MessageThread"
-script_name = "hashbin-worker"
+script_name = "hashbin-worker-prod"
 
 [[durable_objects.bindings]]
 name = "KEY_REGISTRY"
 class_name = "KeyRegistry"
-script_name = "hashbin-worker"
+script_name = "hashbin-worker-prod"
 
 # R2 bucket bindings
 [[r2_buckets]]


### PR DESCRIPTION
The routes in Cloudflare point to "hashbin-worker-prod" but wrangler.toml was deploying to "hashbin-worker". This caused the custom domain hashbin.org to serve old code from the wrong worker while workers.dev served the correct new code.

Changed worker name from "hashbin-worker" to "hashbin-worker-prod" to match the existing route configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration with new service naming.
  * Configured content storage and backup infrastructure.
  * Established database migration framework.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->