### PR TITLE
Add retention slider to upload page with 1/5/10 year stops and quick-selects

### DIFF
--- a/frontend/css/upload.css
+++ b/frontend/css/upload.css
@@ -198,6 +198,49 @@
   box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
 }
 
+/* Retention Slider */
+.retention-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+  gap: 1rem;
+}
+
+.retention-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.retention-subtext {
+  font-size: 0.9rem;
+  color: var(--color-text-light);
+}
+
+.retention-slider {
+  width: 100%;
+  margin-bottom: 0.75rem;
+}
+
+.retention-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.btn-small {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.retention-hint {
+  font-size: 0.85rem;
+  color: var(--color-text-light);
+  margin: 0;
+}
+
 /* Alerts */
 .alert {
   padding: 1rem;

--- a/frontend/js/upload.js
+++ b/frontend/js/upload.js
@@ -26,6 +26,8 @@ async function init() {
   const dropZone = document.getElementById('drop-zone');
   const uploadForm = document.getElementById('upload-form');
   const cancelButton = document.getElementById('cancel-upload');
+  const retentionSlider = document.getElementById('retention-slider');
+  const retentionButtons = document.querySelectorAll('[data-retention]');
   
   // Set up file input
   fileInput.addEventListener('change', handleFileSelect);
@@ -43,11 +45,14 @@ async function init() {
   cancelButton.addEventListener('click', handleCancel);
   
   // Set up retention picker
-  const retentionSelect = document.getElementById('retention-preset');
-  const customRetentionInput = document.getElementById('custom-retention');
-  
-  retentionSelect.addEventListener('change', handleRetentionChange);
-  customRetentionInput.addEventListener('input', handleRetentionChange);
+  retentionSlider.addEventListener('input', handleRetentionChange);
+  retentionButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      retentionSlider.value = button.dataset.retention;
+      handleRetentionChange();
+    });
+  });
+  updateRetentionDisplay();
   
   // Load user balance
   await loadBalance();
@@ -237,6 +242,7 @@ async function checkDuplicate(cid) {
  * Handle retention change
  */
 function handleRetentionChange() {
+  updateRetentionDisplay();
   updateCostDisplay();
 }
 
@@ -244,14 +250,25 @@ function handleRetentionChange() {
  * Get selected retention months
  */
 function getRetentionMonths() {
-  const preset = document.getElementById('retention-preset').value;
-  
-  if (preset === 'custom') {
-    const custom = parseInt(document.getElementById('custom-retention').value);
-    return custom > 0 ? custom : 1;
+  const sliderValue = parseInt(document.getElementById('retention-slider').value, 10);
+  return Number.isNaN(sliderValue) || sliderValue < 1 ? 1 : sliderValue;
+}
+
+/**
+ * Update retention display
+ */
+function updateRetentionDisplay() {
+  const months = getRetentionMonths();
+  const valueElement = document.getElementById('retention-value');
+  const subtextElement = document.getElementById('retention-subtext');
+
+  if (valueElement) {
+    valueElement.textContent = formatRetentionLabel(months);
   }
-  
-  return parseInt(preset);
+
+  if (subtextElement) {
+    subtextElement.textContent = `${months * 30} days`;
+  }
 }
 
 /**
@@ -265,8 +282,9 @@ function updateCostDisplay() {
   
   // Update cost display
   document.getElementById('cost-amount').textContent = formatCents(costCents);
+  const retentionLabel = formatRetentionLabel(months);
   document.getElementById('cost-breakdown').textContent = 
-    `${formatFileSize(selectedFile.size)} × ${months} month(s) @ $${BASE_RATE_PER_GB_PER_MONTH}/GB/month`;
+    `${formatFileSize(selectedFile.size)} × ${retentionLabel} @ $${BASE_RATE_PER_GB_PER_MONTH}/GB/month`;
   
   // Check if inline content (free)
   if (calculatedCID && isInlineContent(calculatedCID)) {
@@ -306,6 +324,22 @@ function calculateCost(sizeBytes, months) {
  */
 function formatCents(cents) {
   return '$' + (cents / 100).toFixed(2);
+}
+
+/**
+ * Format retention label
+ */
+function formatRetentionLabel(months) {
+  if (months === 1) {
+    return '1 month';
+  }
+
+  if (months % 12 === 0) {
+    const years = months / 12;
+    return `${years} year${years === 1 ? '' : 's'} (${months} months)`;
+  }
+
+  return `${months} months`;
 }
 
 /**

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -100,19 +100,32 @@
           
           <!-- Retention Picker -->
           <div class="form-group">
-            <label for="retention-preset">Retention Period</label>
-            <select id="retention-preset" class="form-control">
-              <option value="1">1 month</option>
-              <option value="12">1 year (12 months)</option>
-              <option value="120">1 decade (120 months)</option>
-              <option value="1200">1 century (1200 months)</option>
-              <option value="custom">Custom...</option>
-            </select>
-          </div>
-          
-          <div id="custom-retention-group" class="form-group" style="display: none;">
-            <label for="custom-retention">Custom Months</label>
-            <input type="number" id="custom-retention" class="form-control" min="1" value="1">
+            <label for="retention-slider">Retention Period</label>
+            <div class="retention-summary">
+              <div class="retention-value" id="retention-value">1 month</div>
+              <div class="retention-subtext" id="retention-subtext">30 days</div>
+            </div>
+            <input
+              type="range"
+              id="retention-slider"
+              class="retention-slider"
+              min="1"
+              max="120"
+              step="1"
+              value="1"
+              list="retention-stops"
+            >
+            <datalist id="retention-stops">
+              <option value="12" label="1 year"></option>
+              <option value="60" label="5 years"></option>
+              <option value="120" label="10 years"></option>
+            </datalist>
+            <div class="retention-actions">
+              <button type="button" class="btn btn-secondary btn-small" data-retention="12">1 year</button>
+              <button type="button" class="btn btn-secondary btn-small" data-retention="60">5 years</button>
+              <button type="button" class="btn btn-secondary btn-small" data-retention="120">10 years</button>
+            </div>
+            <p class="retention-hint">Choose any multiple of 30 days or jump to full-year milestones.</p>
           </div>
           
           <!-- Cost Display -->
@@ -166,18 +179,5 @@
   <script type="module" src="/js/app.js"></script>
   <script type="module" src="/js/upload.js"></script>
   
-  <script>
-    // Show custom retention input when "Custom" is selected
-    document.addEventListener('DOMContentLoaded', () => {
-      const retentionSelect = document.getElementById('retention-preset');
-      const customGroup = document.getElementById('custom-retention-group');
-      
-      if (retentionSelect) {
-        retentionSelect.addEventListener('change', (e) => {
-          customGroup.style.display = e.target.value === 'custom' ? 'block' : 'none';
-        });
-      }
-    });
-  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the old retention preset dropdown with a more flexible slider so users can pay for any multiple of 30 days while providing convenient year-based stops. 
- Provide clear UI feedback for the selected retention (months/years and days) and reflect that selection in the cost calculation.

### Description
- Replaced the retention selector and custom input in `frontend/upload.html` with a range slider (`#retention-slider`) (min `1`, max `120`, step `1`) and added a `datalist` with stops at `12`, `60`, and `120` months plus quick-select buttons for `1 year`, `5 years`, and `10 years`.
- Updated `frontend/js/upload.js` to read retention from the slider via `getRetentionMonths()`, added `updateRetentionDisplay()` and `formatRetentionLabel()` to show human-readable labels and day counts, and wired quick-select buttons to update the slider and cost immediately.
- Adjusted cost breakdown formatting to use the retention label in `updateCostDisplay()` while preserving the existing upload request payload (`retention_months` still sent to `/api/content`).
- Added slider-related styles to `frontend/css/upload.css` (`.retention-summary`, `.retention-slider`, `.retention-actions`, `.btn-small`, and hint text).

### Testing
- Launched a local static server with `python -m http.server 8000` and loaded `/upload.html` to validate the UI served correctly, which succeeded.
- Ran a Playwright smoke script to open `http://127.0.0.1:8000/upload.html` and capture a screenshot (`artifacts/upload-retention-slider.png`), which completed successfully and shows the new slider UI.
- No automated unit tests were added or executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ef2ec660483318a03c3dbe198bd6c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned retention selection interface with an interactive slider control for adjusting data retention periods
  * Added quick-select preset buttons for commonly used retention durations (1 year, 5 years, 10 years)
  * Enhanced retention information display with real-time updates showing current selection and associated details

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->